### PR TITLE
avoid dependency on wslib

### DIFF
--- a/unit-test-cli.scd
+++ b/unit-test-cli.scd
@@ -44,7 +44,7 @@ t = Task.new {
 	} {
 		thisProcess.argv.do { |name|
 			if (name.contains("/")) {
-				name = name.basename.removeExtension;
+				name = PathName(name.basename).fileNameWithoutExtension;
 			};
 			if (name.contains(":")) {
 				UnitTest.runTest(name);


### PR DESCRIPTION
removeExtension is an extension to String provided by wslib -
better to stick with stuff from the core so we don't have to
worry about installing Quarks.

Fixes #3.