### PR TITLE
only report at the end of each run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.8
   - 2.3.5
   - 2.4.2
   - 2.5.0

--- a/unit-test-cli.scd
+++ b/unit-test-cli.scd
@@ -41,7 +41,6 @@ t = Task.new {
 				// doesn't look good:
 				0.1.wait;
 			};
-			UnitTest.report;
 		};
 	} {
 		thisProcess.argv.do { |name|
@@ -58,11 +57,12 @@ t = Task.new {
 					UnitTest.new.failed(nil, msg, true);
 				} {
 					"Invoking %.run".format(className).postln;
-					klass.run(reset: false);
+					klass.run(reset: false, report: false);
 				};
 			};
 		};
 	};
+	UnitTest.report;
 	"Finished running test(s): % passes, % failures\n".postf(
 		UnitTest.passes.size,
 		UnitTest.failures.size


### PR DESCRIPTION
Otherwise if multiple test cases are run, after failures occur we see them repeated in the output after every subsequent test case.